### PR TITLE
Use a better value for the default groupId

### DIFF
--- a/src/main/java/org/scijava/plugins/scripting/java/JavaEngine.java
+++ b/src/main/java/org/scijava/plugins/scripting/java/JavaEngine.java
@@ -93,7 +93,7 @@ import org.xml.sax.SAXException;
  */
 public class JavaEngine extends AbstractScriptEngine {
 
-	private final static String DEFAULT_GROUP_ID = "net.imagej";
+	private final static String DEFAULT_GROUP_ID = "org.scijava.scripting.java";
 	private final static String DEFAULT_VERSION = "1.0.0-SNAPSHOT";
 
 	/**

--- a/src/test/java/org/scijava/plugins/scripting/java/JavaEngineTest.java
+++ b/src/test/java/org/scijava/plugins/scripting/java/JavaEngineTest.java
@@ -198,7 +198,7 @@ public class JavaEngineTest {
 			" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0\n" + //
 			" http://maven.apache.org/xsd/maven-4.0.0.xsd\">\n" + //
 			" <modelVersion>4.0.0</modelVersion>\n" + //
-			" <groupId>net.imagej</groupId>\n" + //
+			" <groupId>org.scijava.scripting.java</groupId>\n" + //
 			" <artifactId>MinimalTest</artifactId>\n" + //
 			" <version>1.0.0</version>\n" + //
 			" <build>\n" + //

--- a/src/test/java/org/scijava/plugins/scripting/java/MakeJarTest.java
+++ b/src/test/java/org/scijava/plugins/scripting/java/MakeJarTest.java
@@ -58,10 +58,10 @@ public class MakeJarTest {
 		final File output = new File(tmpDir, "test.jar");
 		engine.makeJar(file, false, output, writer);
 		assertJarEntries(output, "META-INF/MANIFEST.MF",
-				"META-INF/maven/net.imagej/Dummy/pom.xml", "Dummy.class");
+				"META-INF/maven/org.scijava.scripting.java/Dummy/pom.xml", "Dummy.class");
 		engine.makeJar(file, true, output, writer);
 		assertJarEntries(output, "META-INF/MANIFEST.MF",
-				"META-INF/maven/net.imagej/Dummy/pom.xml", "Dummy.class",
+				"META-INF/maven/org.scijava.scripting.java/Dummy/pom.xml", "Dummy.class",
 				"pom.xml", "src/main/java/Dummy.java");
 	}
 


### PR DESCRIPTION
This project migrated from ImageJ2, where `net.imagej` was an intuitive
choice for default groupId. But the project is part of the SciJava
scripting framework now, so a groupId matching that fact makes more
sense.

We use `org.scijava.scripting.java`, rather than only `org.scijava`, to
avoid potential name clashes with actual SciJava projects such as
`scijava-common`, `scripting-java`, etc.
