### PR TITLE
Fix NPE when reader reads null line.

### DIFF
--- a/src/main/java/org/scijava/plugins/scripting/java/JavaEngine.java
+++ b/src/main/java/org/scijava/plugins/scripting/java/JavaEngine.java
@@ -550,8 +550,9 @@ public class JavaEngine extends AbstractScriptEngine {
 			Pattern.compile(".*public class ([a-zA-Z0-9_]*).*");
 		final BufferedReader reader = new BufferedReader(new FileReader(file));
 		for (;;) {
-			String line = reader.readLine().trim();
+			String line = reader.readLine();
 			if (line == null) break;
+			line = line.trim();
 			outerLoop:
 			while (line.startsWith("/*")) {
 				int end = line.indexOf("*/", 2);


### PR DESCRIPTION
Old code called trim() on ``line``, and tested for ``line == null`` afterwards.
If ``line`` is actually ``null`` this will cause an
``NullPointerException``